### PR TITLE
Fields now length protected.

### DIFF
--- a/app/models/ldap_user.rb
+++ b/app/models/ldap_user.rb
@@ -6,6 +6,7 @@ class LdapUser < Activedap
 
   validates :mail, presence: true
   validates :nickname, :gn, :sn, :admissionYear, presence: true
+  validates :mail, :nickname, :gn, :sn, length: { maximum: 100 }
   validate :has_valid_display_format
   validate :has_valid_api_keys
 


### PR DESCRIPTION
This should limit the length of fields Nick, First name and last name as well as email address to a maximum of 100 characters. 

This will make the system more resilient to bad users/usage.

Fixes #70 